### PR TITLE
bug fixed.... change config value

### DIFF
--- a/goopencc.go
+++ b/goopencc.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	ZH2TW = "zhs2zhtw_p.ini"
-	TW2ZH = "zhtw2zhcn_s.ini"
+	ZH2TW = "s2twp.json"
+	TW2ZH = "tw2sp.json"
 )
 
 func Zh2Tw(v string) (string, int) {


### PR DESCRIPTION
**before**

```
go test
--- FAIL: TestZh2Tw (0.50s)
    goopencc_test.go:10: 500 : Internal Server Error != 滑鼠
--- FAIL: TestTw2Zh (0.15s)
    goopencc_test.go:21: 500 : Internal Server Error != 鼠标
FAIL
exit status 1
FAIL    _/home/goodjob/sandbox/go-practice/go-opencc-crawler    0.661s
```

**after**

```
go test
PASS
ok      _/home/goodjob/sandbox/go-practice/go-opencc-crawler    0.479s
```
